### PR TITLE
Fix approval tx check and refresh balance

### DIFF
--- a/src/components/swap-history/index.tsx
+++ b/src/components/swap-history/index.tsx
@@ -14,12 +14,14 @@ import constantKeys from "i18n/constant-keys";
 import { ChevronRight, CircleCheckBig, OctagonAlert, Trash } from "icons";
 import MiddleTruncate from "components/middle-truncate";
 import { Empty, Spin, Tooltip } from "antd";
+import { useBaseContext } from "context";
 
 const Transaction: FC<{ address: string; transaction: TransactionProps }> = ({
   address,
   transaction,
 }) => {
   const { t } = useTranslation();
+  const { tokens, updateTokenBalances } = useBaseContext();
   const { getTxStatus } = useSwapVult();
   const {
     allocateAmount,
@@ -41,6 +43,7 @@ const Transaction: FC<{ address: string; transaction: TransactionProps }> = ({
             }, 1000 * 10);
           } else {
             setStoredTransaction(address, { ...transaction, status });
+            updateTokenBalances(Object.values(tokens));
           }
         })
         .catch(() => {});

--- a/src/components/swap-vult/index.tsx
+++ b/src/components/swap-vult/index.tsx
@@ -189,6 +189,10 @@ const Component: FC = () => {
                 hash: txHash,
                 status: TxStatus.PENDING,
               });
+              
+              // Clear the tokenIn input amount
+              form.setFieldValue("allocateAmount", 0);
+              form.setFieldValue("buyAmount", undefined);
             }
           })
           .finally(() => {

--- a/src/components/swap-vult/index.tsx
+++ b/src/components/swap-vult/index.tsx
@@ -47,7 +47,7 @@ const Component: FC = () => {
     swapping,
     values,
   } = state;
-  const { currency, tokens } = useBaseContext();
+  const { currency, tokens, updateTokenBalances } = useBaseContext();
   const { address, isConnected } = useAccount();
   const [form] = Form.useForm<SwapFormProps>();
   const {
@@ -308,6 +308,7 @@ const Component: FC = () => {
     if (!loading) {
       const { allocateToken, buyAmount, buyToken } = form.getFieldsValue();
       handleUpdateQuote(buyToken, allocateToken, buyAmount, false);
+      updateTokenBalances([tokens[allocateToken], tokens[buyToken]]);
     }
   };
 

--- a/src/components/swap-vult/index.tsx
+++ b/src/components/swap-vult/index.tsx
@@ -524,6 +524,7 @@ const Component: FC = () => {
                         </span>
                       ) : approving ? (
                         <span className="button button-secondary disabled">
+                          <Spin size="small" style={{ marginRight: 8 }} />
                           {t(constantKeys.APPROVING)}
                         </span>
                       ) : (

--- a/src/i18n/constant-keys.ts
+++ b/src/i18n/constant-keys.ts
@@ -89,7 +89,10 @@ export default keyMirror({
   TOTAL_VULT_STAKED: true,
   TOTAL_WL_ALLOCATION: true,
   TRANSACTIONS: true,
+  TRANSACTION_FAILED: true,
   TRANSACTION_SETTINGS: true,
+  TRANSACTION_SUCCESS: true,
+  TRANSACTION_TIMEOUT: true,
   // U
   USED_ALLOCATION: true,
   // V

--- a/src/i18n/constant-keys.ts
+++ b/src/i18n/constant-keys.ts
@@ -7,6 +7,7 @@ export default keyMirror({
   AMOUNT: true,
   AMOUNT_STAKED: true,
   APPROVE: true,
+  APPROVING: true,
   AVAILABLE: true,
   // B
   BASIC: true,

--- a/src/i18n/locales/en_UK.ts
+++ b/src/i18n/locales/en_UK.ts
@@ -90,6 +90,9 @@ export default {
   [translation.TOTAL_VULT_STAKED]: "Total VULT Staked",
   [translation.TOTAL_WL_ALLOCATION]: "Total WL allocation",
   [translation.TRANSACTION_SETTINGS]: "Transaction Settings",
+  [translation.TRANSACTION_FAILED]: "Transaction failed",
+  [translation.TRANSACTION_SUCCESS]: "Transaction successful",
+  [translation.TRANSACTION_TIMEOUT]: "Transaction timeout - please try again",
   [translation.TRANSACTIONS]: "Transactions",
   [translation.USED_ALLOCATION]: "Used Allocation",
   // U

--- a/src/i18n/locales/en_UK.ts
+++ b/src/i18n/locales/en_UK.ts
@@ -7,6 +7,7 @@ export default {
   [translation.AMOUNT]: "Amount",
   [translation.AMOUNT_STAKED]: "Amount Staked",
   [translation.APPROVE]: "Approve",
+  [translation.APPROVING]: "Approving",
   [translation.AVAILABLE]: "Available",
   // B
   [translation.BASIC]: "Basic",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval now yields a transaction hash and is confirmed via on-chain polling before proceeding.
  * New transaction status messages (success, failed, timeout) added to the UI.

* **Improvements**
  * Token balances auto-refresh after transactions, quote updates, and manual refresh.
  * Shows a warning for full-amount swaps when balance/gas is insufficient.
  * Approval UI label updated to "Approving".
  * Exposes an explicit "update token balances" capability for UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->