### PR TITLE
Add ethAddress field to whitelist request

### DIFF
--- a/src/pages/Claim.tsx
+++ b/src/pages/Claim.tsx
@@ -653,7 +653,8 @@ export const ClaimPage = () => {
         await api.registerVultisigWallet(
           vultisigWallet,
           challengeMessage,
-          signature
+          signature,
+          vultisigWallet.account
         );
 
         const result = await api.attestAddress(vultisigWallet.account);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -135,7 +135,8 @@ export const api = {
   registerVultisigWallet: async (
     wallet: VultisigWalletProps,
     message: string,
-    signature: string
+    signature: string,
+    ethAddress: string
   ) => {
     const { data } = await fetchTalkApi.post<{
       id: number;
@@ -147,6 +148,7 @@ export const api = {
       ...wallet,
       message,
       signature,
+      ethAddress,
     });
     return data;
   },


### PR DESCRIPTION
## Summary
- Pass the vault's Ethereum address (`ethAddress`) in the `POST /whitelist` request body, as the backend no longer derives it server-side
- The address comes from `eth_requestAccounts` (the same account used for `personal_sign`)

## Related
Backend PR: https://github.com/vultisig/arena-be/pull/2

## Test plan
- [ ] Connect a Vultisig wallet and verify the whitelist request includes `ethAddress`
- [ ] Confirm whitelist registration succeeds with the updated backend
- [ ] Verify error handling for invalid/mismatched addresses (400/401 responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated wallet registration flow to include additional account information during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->